### PR TITLE
make 'mode' an enum

### DIFF
--- a/src/ntp.rs
+++ b/src/ntp.rs
@@ -137,7 +137,7 @@ fn test_ntp_packet1() {
     let expected = IResult::Done(empty,NtpPacket{
         li:3,
         version:3,
-        mode:NtpMode::new(1),
+        mode:NtpMode::new(1).unwrap(),
         stratum:0,
         poll:10,
         precision:-6,
@@ -171,7 +171,7 @@ fn test_ntp_packet2() {
     let expected = IResult::Done(empty,NtpPacket{
         li:0,
         version:4,
-        mode:NtpMode::new(3),
+        mode:NtpMode::new(3).unwrap(),
         stratum:0,
         poll:0,
         precision:0,

--- a/src/ntp.rs
+++ b/src/ntp.rs
@@ -1,10 +1,29 @@
 use nom::{be_i8,be_u8,be_u16,be_u32,be_u64};
+use std::mem::transmute;
+
+#[derive(Debug,PartialEq,Eq)]
+pub enum NtpMode {
+    Reserved = 0,
+    SymmetricActive = 1,
+    SymmetricPassive = 2,
+    Client = 3,
+    Server = 4,
+    Broadcast = 5,
+    NtpControlMessage = 6,
+    Private = 7,
+}
+
+impl NtpMode {
+    pub fn new(m: u8) -> NtpMode {
+        unsafe { transmute(m) }
+    }
+}
 
 #[derive(Debug,PartialEq)]
 pub struct NtpPacket<'a> {
     pub li: u8,
     pub version: u8,
-    pub mode: u8,
+    pub mode: NtpMode,
     pub stratum: u8,
     pub poll: i8,
     pub precision: i8,
@@ -75,7 +94,7 @@ named!(pub parse_ntp<NtpPacket>,
            NtpPacket {
                li:b0.0,
                version:b0.1,
-               mode:b0.2,
+               mode:NtpMode::new(b0.2),
                stratum:st,
                poll:pl,
                precision:pr,
@@ -111,7 +130,7 @@ fn test_ntp_packet1() {
     let expected = IResult::Done(empty,NtpPacket{
         li:3,
         version:3,
-        mode:1,
+        mode:NtpMode::new(1),
         stratum:0,
         poll:10,
         precision:-6,
@@ -145,7 +164,7 @@ fn test_ntp_packet2() {
     let expected = IResult::Done(empty,NtpPacket{
         li:0,
         version:4,
-        mode:3,
+        mode:NtpMode::new(3),
         stratum:0,
         poll:0,
         precision:0,

--- a/src/ntp.rs
+++ b/src/ntp.rs
@@ -14,8 +14,15 @@ pub enum NtpMode {
 }
 
 impl NtpMode {
-    pub fn new(m: u8) -> NtpMode {
-        unsafe { transmute(m) }
+    pub unsafe fn new_unchecked(m: u8) -> NtpMode {
+        transmute(m)
+    }
+    pub fn new(m: u8) -> Option<NtpMode> {
+        if (m & 0xF8u8) == 0 {
+            unsafe { Some(NtpMode::new_unchecked(m)) }
+        } else {
+            None
+        }
     }
 }
 
@@ -94,7 +101,7 @@ named!(pub parse_ntp<NtpPacket>,
            NtpPacket {
                li:b0.0,
                version:b0.1,
-               mode:NtpMode::new(b0.2),
+               mode:unsafe { NtpMode::new_unchecked(b0.2) },
                stratum:st,
                poll:pl,
                precision:pr,


### PR DESCRIPTION
Make `mode` an `NtpMode` enum instead of a plain integer; it's more explicit and still easy to convert to an int if needs be (just add e.g. `as i8`):
```rust
pub enum NtpMode {
    Reserved = 0,
    SymmetricActive = 1,
    SymmetricPassive = 2,
    Client = 3,
    Server = 4,
    Broadcast = 5,
    NtpControlMessage = 6,
    Private = 7,
}
```